### PR TITLE
Add Python 3.10 to CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,7 +28,9 @@ jobs:
           python3 -m pip install cython
           python3 -m pip install git+https://github.com/PyTables/PyTables
       - name: Install SimWeights
-        run: pip install .[test] --use-feature=in-tree-build
+        run: |
+          python -m pip install flit
+          python -m flit install --symlink --extras test
       - name: Run Tests
         run: pytest
       - name: Upload Coverage to Codecov

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install SimWeights
         run: |
           python -m pip install flit
-          python -m flit install --symlink --deps=none --extras=test
+          python -m flit install --symlink --deps=production --extras=test
       - name: Run Tests
         run: pytest
       - name: Upload Coverage to Codecov

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Ubuntu Deps
-        if: ${{ contains( matrix.os, 'ubuntu') && contains( matrix.python-version, '3.10'}}
+        if: ${{ contains( matrix.os, 'ubuntu') && contains( matrix.python-version, '3.10') }}
         run: sudo apt-get install libblosc-dev liblzo2-dev libhdf5-dev
       - name: Install Homebrew Deps
         if: ${{ contains( matrix.os, 'macos') && ( contains( matrix.python-version, '3.9') || contains( matrix.python-version, '3.10') ) }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,12 +15,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Ubuntu Deps
-        if: ${{ contains( matrix.os, 'ubuntu') }}      
+        if: ${{ contains( matrix.os, 'ubuntu') && contains( matrix.python-version, '3.10'}}
         run: sudo apt-get install libblosc-dev liblzo2-dev libhdf5-dev
       - name: Install Homebrew Deps
-        if: ${{ contains( matrix.os, 'macos') }}      
-        run: brew install c-blosc lzo hdf5
-      - name: Install Pip
+        if: ${{ contains( matrix.os, 'macos') && ( contains( matrix.python-version, '3.9') || contains( matrix.python-version, '3.10') ) }}
+        run: brew install c-blosc hdf5
+      - name: Upgrading Pip
         run: python3 -m pip install --upgrade pip
       - name: Install PyTables from main
         if: ${{ contains( matrix.python-version, '3.10') }} 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,18 +16,18 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Ubuntu Deps
         if: ${{ contains( matrix.os, 'ubuntu') && contains( matrix.python-version, '3.10') }}
-        run: sudo apt-get install libblosc-dev liblzo2-dev libhdf5-dev
+        run: sudo apt-get install libblosc-dev libhdf5-dev
       - name: Install Homebrew Deps
         if: ${{ contains( matrix.os, 'macos') && ( contains( matrix.python-version, '3.9') || contains( matrix.python-version, '3.10') ) }}
         run: brew install c-blosc hdf5
-      - name: Upgrading Pip
+      - name: Upgrade Pip
         run: python3 -m pip install --upgrade pip
       - name: Install PyTables from main
         if: ${{ contains( matrix.python-version, '3.10') }} 
         run: |
           python3 -m pip install cython
           python3 -m pip install git+https://github.com/PyTables/PyTables
-      - name: Install dependencies
+      - name: Install SimWeights
         run: pip install .[test] --use-feature=in-tree-build
       - name: Tests
         run: pytest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install SimWeights
         run: |
           python -m pip install flit
-          python -m flit install --symlink --extras test
+          python -m flit install --symlink --deps=none --extras=test
       - name: Run Tests
         run: pytest
       - name: Upload Coverage to Codecov

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,12 +19,16 @@ jobs:
         run: sudo apt-get install libblosc-dev liblzo2-dev libhdf5-dev
       - name: Install Homebrew Deps
         if: ${{ contains( matrix.os, 'macos') }}      
-        run: brew install lzo hdf5
-      - name: Install dependencies
+        run: brew install c-blosc lzo hdf5
+      - name: Install Pip
+        run: python3 -m pip install --upgrade pip
+      - name: Install PyTables from main
+        if: ${{ contains( matrix.python-version, '3.10') }} 
         run: |
-          python3 -m pip install --upgrade pip
           python3 -m pip install cython
           python3 -m pip install git+https://github.com/PyTables/PyTables
+      - name: Install dependencies
+        run: |
           python3 -m pip install flit
           python3 -m flit install --symlink
       - name: Tests

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,22 +14,22 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Ubuntu Deps
+      - name: Apt-Get Install Deps
         if: ${{ contains( matrix.os, 'ubuntu') && contains( matrix.python-version, '3.10') }}
         run: sudo apt-get install libblosc-dev libhdf5-dev
-      - name: Install Homebrew Deps
+      - name: HomeBrew Install Deps
         if: ${{ contains( matrix.os, 'macos') && ( contains( matrix.python-version, '3.9') || contains( matrix.python-version, '3.10') ) }}
         run: brew install c-blosc hdf5
       - name: Upgrade Pip
         run: python3 -m pip install --upgrade pip
-      - name: Install PyTables from main
+      - name: Install PyTables from GitHub
         if: ${{ contains( matrix.python-version, '3.10') }} 
         run: |
           python3 -m pip install cython
           python3 -m pip install git+https://github.com/PyTables/PyTables
       - name: Install SimWeights
         run: pip install .[test] --use-feature=in-tree-build
-      - name: Tests
+      - name: Run Tests
         run: pytest
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,19 +14,21 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install Ubuntu Deps
+        if: ${{ contains( matrix.os, 'ubuntu') }}      
+        run: sudo apt-get install libblosc-dev liblzo2-dev libhdf5-dev
       - name: Install Homebrew Deps
         if: ${{ contains( matrix.os, 'macos') }}      
-        run: |
-          brew install hdf5 c-blosc
-          HDF5_DIR="$(brew --prefix)/opt/hdf5" pip3 install tables
+        run: brew install lzo hdf5
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install flit
-          python -m flit install --symlink
+          python3 -m pip install --upgrade pip
+          python3 -m pip install cython
+          python3 -m pip install git+https://github.com/PyTables/PyTables
+          python3 -m pip install flit
+          python3 -m flit install --symlink
       - name: Tests
-        run: |
-          pytest
+        run: pytest
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,9 +28,7 @@ jobs:
           python3 -m pip install cython
           python3 -m pip install git+https://github.com/PyTables/PyTables
       - name: Install dependencies
-        run: |
-          python3 -m pip install flit
-          python3 -m flit install --symlink
+        run: pip install .[test] --use-feature=in-tree-build
       - name: Tests
         run: pytest
       - name: Upload Coverage to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'Topic :: Scientific/Engineering :: Astronomy',
     'Topic :: Scientific/Engineering :: Physics',
     ]
@@ -26,11 +27,8 @@ classifiers = [
 simweights = "simweights.cmdline:main"
 
 [tool.flit.metadata.requires-extra]
-test = ["pytest-cov", "pytest-isort", "pytest-black", "pytest-flake8", "pytest-pylint"]
+test = ["h5py", "tables", "pandas", "pytest-cov", "pytest-isort", "pytest-black", "pytest-flake8", "pytest-pylint"]
 docs = ["sphinx","sphinx-rtd-theme","pandas"]
-h5py = ["h5py"]
-tables = ["tables"]
-pandas = ["pandas"]
 
 [tool.coverage.run]
 source = ["simweights"]


### PR DESCRIPTION
The latest release of PyTables does not work with python 3.10 so it has to be pip installed from its github url in order to work. When a new release of pytables is available this should be changed