### PR TITLE
Adding flux weighting option to the effective_area function of Weighter objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ warn_unreachable = true
 max-line-length = "128"
 
 [tool.pylint.messages_control]
-disable = "C0114,R0902,R0913,R0917"
+disable = "C0114,R0902,R0913,R0917,R0914"
 
 [tool.pytest.ini_options]
 addopts = ["-ra", "--strict-config", "--strict-markers", "--cov=simweights", "-W ignore"]

--- a/src/simweights/_spatial.py
+++ b/src/simweights/_spatial.py
@@ -88,7 +88,7 @@ class UniformSolidAngleCylinder(CylinderBase):
 
     """
 
-    def _pdf(self: UniformSolidAngleCylinder, cos_zen: NDArray[np.float64]) -> NDArray[np.float64]:
+    def _pdf(self: UniformSolidAngleCylinder, cos_zen: NDArray[np.float64]) -> NDArray[np.floating]:
         return 1 / (2 * np.pi * (self.cos_zen_max - self.cos_zen_min) * self.projected_area(cos_zen))
 
     def pdf(self: UniformSolidAngleCylinder, cos_zen: ArrayLike) -> NDArray[np.float64]:

--- a/src/simweights/_utils.py
+++ b/src/simweights/_utils.py
@@ -27,9 +27,9 @@ class Column:
     def __init__(self: Column, colname: str | None = None) -> None:
         self.columns = (colname,)
 
-    def pdf(self: Column, value: ArrayLike) -> NDArray[np.float64]:
+    def pdf(self: Column, value: ArrayLike) -> NDArray[np.floating]:
         r"""Probability density function."""
-        return 1 / np.asarray(value, dtype=np.float64)
+        return 1.0 / np.asarray(value, dtype=np.float64)
 
     def __eq__(self: Column, other: object) -> bool:
         return isinstance(other, Column) and self.columns == other.columns
@@ -91,7 +91,7 @@ def get_column(table: Any, name: str) -> NDArray[np.float64]:
     return np.asarray(column, dtype=np.float64)
 
 
-def constcol(table: Any, colname: str, mask: NDArray[np.bool_] | None = None) -> float:
+def constcol(table: Any, colname: str, mask: ArrayLike | None = None) -> float:
     """Helper function which makes sure that all of the entries in a column are exactly the same.
 
     This is necessary because CORSIKA and NuGen store generation surface parameters in every frame and we
@@ -99,7 +99,7 @@ def constcol(table: Any, colname: str, mask: NDArray[np.bool_] | None = None) ->
     """
     col = get_column(table, colname)
     if mask is not None:
-        col = col[mask]
+        col = col[np.asarray(mask, dtype=bool)]
     val = col[0]
     assert np.ndim(val) == 0
     assert (val == col).all()

--- a/src/simweights/_weighter.py
+++ b/src/simweights/_weighter.py
@@ -139,8 +139,8 @@ class Weighter:
         self: Weighter,
         energy_bins: ArrayLike,
         cos_zenith_bins: ArrayLike,
-        flux: Any = 1e-4,  # default is 1 GeV^-1 m^-2 sr^-1 flux
         mask: ArrayLike | None = None,
+        flux: Any = 1e-4,  # default is 1 GeV^-1 m^-2 sr^-1 flux
     ) -> NDArray[np.float64]:
         r"""Calculate The effective area for the given energy and zenith bins.
 

--- a/src/simweights/_weighter.py
+++ b/src/simweights/_weighter.py
@@ -207,10 +207,21 @@ class Weighter:
             effective_area_binned = np.asarray(hist_val / (e_width * 2 * np.pi * z_width * nspecies), dtype=np.float64)
         elif callable(flux):
             flux_pdgids = [pdgid.value for pdgid in flux.pdgids]
+
             def flux_func(energy: ArrayLike) -> NDArray[np.float64]:
-                return sum(flux._funcs[flux_pdgids.index(np.unique(self.get_weight_column("pdgid")[maska])[i_species])](energy) for i_species in range(nspecies))
+                return sum(
+                    flux._funcs[flux_pdgids.index(np.unique(self.get_weight_column("pdgid")[maska])[i_species])](energy)
+                    for i_species in range(nspecies)
+                )
+
             from scipy.integrate import quad
-            flux_integrals = np.asarray([quad(flux_func, energy_bins[bin_index], energy_bins[bin_index+1])[0] for bin_index in range(len(energy_bins)-1)])
+
+            flux_integrals = np.asarray(
+                [
+                    quad(flux_func, energy_bins[bin_index], energy_bins[bin_index + 1])[0]
+                    for bin_index in range(len(energy_bins) - 1)
+                ]
+            )
             e_width, z_width = np.meshgrid(flux_integrals, np.ediff1d(czbin))
             effective_area_binned = np.asarray(1e-4 * hist_val / (e_width * 2 * np.pi * z_width), dtype=np.float64)
         else:

--- a/src/simweights/_weighter.py
+++ b/src/simweights/_weighter.py
@@ -139,6 +139,7 @@ class Weighter:
         self: Weighter,
         energy_bins: ArrayLike,
         cos_zenith_bins: ArrayLike,
+        flux: Any = 1e-4, # default is 1 GeV^-1 m^-2 sr^-1 flux
         mask: ArrayLike | None = None,
     ) -> NDArray[np.float64]:
         r"""Calculate The effective area for the given energy and zenith bins.
@@ -182,7 +183,7 @@ class Weighter:
         energy = self.get_weight_column("energy")
         cos_zen = self.get_weight_column("cos_zen")
 
-        weights = self.get_weights(1e-4)
+        weights = self.get_weights(flux)
         maska = np.full(weights.size, 1, dtype=bool) if mask is None else np.asarray(mask, dtype=bool)
 
         assert maska.shape == weights.shape
@@ -198,8 +199,18 @@ class Weighter:
 
         assert np.array_equal(enbin, energy_bins)
         assert np.array_equal(czbin, cos_zenith_bins)
-        e_width, z_width = np.meshgrid(np.ediff1d(enbin), np.ediff1d(czbin))
-        return np.asarray(hist_val / (e_width * 2 * np.pi * z_width * nspecies), dtype=np.float64)
+        if np.isscalar(flux):
+            e_width, z_width = np.meshgrid(np.ediff1d(enbin), np.ediff1d(czbin))
+            return np.asarray(hist_val / (e_width * 2 * np.pi * z_width * nspecies), dtype=np.float64)
+        elif callable(flux):
+            flux_pdgids = [pdgid.value for pdgid in flux.pdgids]
+            flux_func = lambda E: sum([flux._funcs[flux_pdgids.index(np.unique(self.get_weight_column("pdgid")[maska])[i_species])](E) for i_species in range(nspecies)])
+            from scipy.integrate import quad
+            flux_integrals = np.asarray([quad(flux_func, energy_bins[bin_index], energy_bins[bin_index+1])[0] for bin_index in range(len(energy_bins)-1)])
+            e_width, z_width = np.meshgrid(flux_integrals, np.ediff1d(czbin))
+            return np.asarray(1e-4 * hist_val / (e_width * 2 * np.pi * z_width), dtype=np.float64)
+        else:
+            raise ValueError("only scalar flux or cosmic ray flux models are supported right now")
 
     def __add__(self: Weighter, other: Weighter | int) -> Weighter:
         if other == 0:

--- a/src/simweights/_weighter.py
+++ b/src/simweights/_weighter.py
@@ -207,10 +207,21 @@ class Weighter:
             return np.asarray(hist_val / (e_width * 2 * np.pi * z_width * nspecies), dtype=np.float64)
         elif callable(flux):
             flux_pdgids = [pdgid.value for pdgid in flux.pdgids]
+
             def flux_func(energy):
-                return sum(flux._funcs[flux_pdgids.index(np.unique(self.get_weight_column("pdgid")[maska])[i_species])](energy) for i_species in range(nspecies))
+                return sum(
+                    flux._funcs[flux_pdgids.index(np.unique(self.get_weight_column("pdgid")[maska])[i_species])](energy)
+                    for i_species in range(nspecies)
+                )
+
             from scipy.integrate import quad
-            flux_integrals = np.asarray([quad(flux_func, energy_bins[bin_index], energy_bins[bin_index+1])[0] for bin_index in range(len(energy_bins)-1)])
+
+            flux_integrals = np.asarray(
+                [
+                    quad(flux_func, energy_bins[bin_index], energy_bins[bin_index + 1])[0]
+                    for bin_index in range(len(energy_bins) - 1)
+                ]
+            )
             e_width, z_width = np.meshgrid(flux_integrals, np.ediff1d(czbin))
             return np.asarray(1e-4 * hist_val / (e_width * 2 * np.pi * z_width), dtype=np.float64)
         else:

--- a/src/simweights/_weighter.py
+++ b/src/simweights/_weighter.py
@@ -139,7 +139,7 @@ class Weighter:
         self: Weighter,
         energy_bins: ArrayLike,
         cos_zenith_bins: ArrayLike,
-        flux: Any = 1e-4, # default is 1 GeV^-1 m^-2 sr^-1 flux
+        flux: Any = 1e-4,  # default is 1 GeV^-1 m^-2 sr^-1 flux
         mask: ArrayLike | None = None,
     ) -> NDArray[np.float64]:
         r"""Calculate The effective area for the given energy and zenith bins.
@@ -204,9 +204,20 @@ class Weighter:
             return np.asarray(hist_val / (e_width * 2 * np.pi * z_width * nspecies), dtype=np.float64)
         elif callable(flux):
             flux_pdgids = [pdgid.value for pdgid in flux.pdgids]
-            flux_func = lambda E: sum([flux._funcs[flux_pdgids.index(np.unique(self.get_weight_column("pdgid")[maska])[i_species])](E) for i_species in range(nspecies)])
+            flux_func = lambda E: sum(
+                [
+                    flux._funcs[flux_pdgids.index(np.unique(self.get_weight_column("pdgid")[maska])[i_species])](E)
+                    for i_species in range(nspecies)
+                ]
+            )
             from scipy.integrate import quad
-            flux_integrals = np.asarray([quad(flux_func, energy_bins[bin_index], energy_bins[bin_index+1])[0] for bin_index in range(len(energy_bins)-1)])
+
+            flux_integrals = np.asarray(
+                [
+                    quad(flux_func, energy_bins[bin_index], energy_bins[bin_index + 1])[0]
+                    for bin_index in range(len(energy_bins) - 1)
+                ]
+            )
             e_width, z_width = np.meshgrid(flux_integrals, np.ediff1d(czbin))
             return np.asarray(1e-4 * hist_val / (e_width * 2 * np.pi * z_width), dtype=np.float64)
         else:

--- a/tests/test_weighter.py
+++ b/tests/test_weighter.py
@@ -223,7 +223,6 @@ class TestWeighter(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             self.weighter1.effective_area([5e5, 5e6], [0, 1], flux=list(range(self.N1)))
-        
 
     def test_weighter_addition(self):
         weighter_sum = self.weighter1 + self.weighter1

--- a/tests/test_weighter.py
+++ b/tests/test_weighter.py
@@ -207,6 +207,23 @@ class TestWeighter(unittest.TestCase):
             self.weighter1.effective_area(np.linspace(5e5, 5e6, self.N1 + 1), [0, 1]),
             [np.full(self.N1, self.c1.etendue / 2e4 / np.pi)],
         )
+        self.assertAlmostEqual(
+            self.weighter1.effective_area([5e5, 5e6], [0, 1], flux=TIG1996())[0][0],
+            149998.97822505102,
+            6,
+        )
+        self.assertAlmostEqual(
+            self.weighter1.effective_area([5e5, 5e6], [0, 1], np.ones(self.N1, dtype=bool), flux=TIG1996())[0][0],
+            149998.97822505102,
+            6,
+        )
+
+        with self.assertRaises(ValueError):
+            self.weighter1.effective_area([5e5, 5e6], [0, 1], flux="flux")
+
+        with self.assertRaises(TypeError):
+            self.weighter1.effective_area([5e5, 5e6], [0, 1], flux=list(range(self.N1)))
+        
 
     def test_weighter_addition(self):
         weighter_sum = self.weighter1 + self.weighter1


### PR DESCRIPTION
Instead of weighting to a 1 GeV⁻¹ m⁻² sr⁻¹ flux, one can now chose to use any of the cosmic ray flux models available in `simweights` as well in order take into account the spectral shape and varying mass composition inside energy bins. The scalar flux is still possible and the default (`1e-4`).

The plots demonstrate the slight correction of effective area resulting from weighting with three common CR flux models vs the default (scalar flux) for

- proton and iron together
- proton primaries only
- iron primaries only

![simweights_weighting_demo_1](https://github.com/user-attachments/assets/727ec45b-89ca-43b7-bb0e-44f23a98c1bc)
![simweights_weighting_demo_2](https://github.com/user-attachments/assets/81a1d2ca-3a73-4b8c-a1ab-1f6c99bd85a0)