### PR TITLE
Update _icetop_weighter.py

### DIFF
--- a/src/simweights/_corsika_weighter.py
+++ b/src/simweights/_corsika_weighter.py
@@ -24,28 +24,33 @@ def sframe_corsika_surface(table: Any) -> GenerationSurface:
     `I3PrimaryInjectorInfo` and `I3CorsikaInfo` use exactly the same names for quantities.
     """
     surfaces = []
-
+    cylinder_height = get_column(table, "cylinder_height")
+    cylinder_radius = get_column(table, "cylinder_radius")
+    max_zenith = get_column(table, "max_zenith")
+    min_zenith = get_column(table, "min_zenith")
+    power_law_index = get_column(table, "power_law_index")
+    min_energy = get_column(table, "min_energy")
+    max_energy = get_column(table, "max_energy")
+    n_events = get_column(table, "n_events")
     for i in range(len(get_column(table, "n_events"))):
         assert get_column(table, "power_law_index")[i] <= 0
         spatial = NaturalRateCylinder(
-            get_column(table, "cylinder_height")[i],
-            get_column(table, "cylinder_radius")[i],
-            np.cos(get_column(table, "max_zenith")[i]),
-            np.cos(get_column(table, "min_zenith")[i]),
+            cylinder_height[i],
+            cylinder_radius[i],
+            np.cos(max_zenith[i]),
+            np.cos(min_zenith[i]),
             "cos_zen",
         )
         spectrum = PowerLaw(
-            get_column(table, "power_law_index")[i],
-            get_column(table, "min_energy")[i],
-            get_column(table, "max_energy")[i],
+            power_law_index[i],
+            min_energy[i],
+            max_energy[i],
             "energy",
         )
         oversampling_val = get_column(table, "oversampling")[i] if has_column(table, "oversampling") else 1
         pdgid = int(get_column(table, "primary_type")[i])
         surfaces.append(
-            get_column(table, "n_events")[i]
-            * oversampling_val
-            * generation_surface(pdgid, Column("event_weight"), spectrum, spatial),
+            n_events[i] * oversampling_val * generation_surface(pdgid, Column("event_weight"), spectrum, spatial),
         )
     retval = sum(surfaces)
     assert isinstance(retval, GenerationSurface)

--- a/src/simweights/_genie_weighter.py
+++ b/src/simweights/_genie_weighter.py
@@ -61,25 +61,31 @@ def genie_icetray_surface(
 def genie_reader_surface(table: Iterable[Mapping[str, float]]) -> GenerationSurface:
     """Inspect the rows of a GENIE S-Frame table object to generate a surface object."""
     surfaces = []
-
-    for i in range(len(get_column(table, "n_flux_events"))):
-        assert get_column(table, "power_law_index")[i] >= 0
+    n_flux_events = get_column(table, "n_flux_events")
+    power_law_index = get_column(table, "power_law_index")
+    cylinder_radius = get_column(table, "cylinder_radius")
+    max_zenith = get_column(table, "max_zenith")
+    min_zenith = get_column(table, "min_zenith")
+    min_energy = get_column(table, "min_energy")
+    max_energy = get_column(table, "max_energy")
+    primary_type = get_column(table, "primary_type")
+    n_flux_events = get_column(table, "n_flux_events")
+    global_probability_scale = get_column(table, "global_probability_scale")
+    for i, nevents in enumerate(n_flux_events):
+        assert power_law_index[i] >= 0
         spatial = CircleInjector(
-            get_column(table, "cylinder_radius")[i],
-            np.cos(get_column(table, "max_zenith")[i]),
-            np.cos(get_column(table, "min_zenith")[i]),
+            cylinder_radius[i],
+            np.cos(max_zenith[i]),
+            np.cos(min_zenith[i]),
         )
         spectrum = PowerLaw(
-            -get_column(table, "power_law_index")[i],
-            get_column(table, "min_energy")[i],
-            get_column(table, "max_energy")[i],
+            -power_law_index[i],
+            min_energy[i],
+            max_energy[i],
             "energy",
         )
-        pdgid = int(get_column(table, "primary_type")[i])
-        nevents = get_column(table, "n_flux_events")[i]
-        global_probability_scale = get_column(table, "global_probability_scale")[i]
-
-        const_factor = 1 / spatial.etendue / global_probability_scale
+        pdgid = int(primary_type[i])
+        const_factor = 1 / spatial.etendue / global_probability_scale[i]
         surfaces.append(
             nevents * generation_surface(pdgid, Const(const_factor), Column("wght"), Column("volscale"), spectrum),
         )

--- a/src/simweights/_icetop_weighter.py
+++ b/src/simweights/_icetop_weighter.py
@@ -17,7 +17,7 @@ from ._weighter import Weighter
 def sframe_icetop_surface(table: Any) -> GenerationSurface:
     """Inspect the rows of a I3TopInjectorInfo S-Frame table object to generate a surface object."""
     surfaces = []
-    
+
     n_events = get_column(table, "n_events")
     power_law_index = get_column(table, "power_law_index")
     min_energy = get_column(table, "min_energy")

--- a/src/simweights/_icetop_weighter.py
+++ b/src/simweights/_icetop_weighter.py
@@ -17,7 +17,7 @@ from ._weighter import Weighter
 def sframe_icetop_surface(table: Any) -> GenerationSurface:
     """Inspect the rows of a I3TopInjectorInfo S-Frame table object to generate a surface object."""
     surfaces = []
-
+    
     n_events = get_column(table, "n_events")
     power_law_index = get_column(table, "power_law_index")
     min_energy = get_column(table, "min_energy")

--- a/src/simweights/_icetop_weighter.py
+++ b/src/simweights/_icetop_weighter.py
@@ -27,7 +27,7 @@ def sframe_icetop_surface(table: Any) -> GenerationSurface:
     min_zenith = np.cos(get_column(table, "min_zenith"))
     primary_type = get_column(table, "primary_type")
 
-    for i in range(len(n_events)):
+    for i, nevents in enumerate(n_events):
         assert power_law_index[i] <= 0
         spectrum = PowerLaw(  # pylint: disable=duplicate-code
             power_law_index[i],
@@ -42,7 +42,6 @@ def sframe_icetop_surface(table: Any) -> GenerationSurface:
             min_zenith[i],
             "cos_zen",
         )
-        nevents = n_events[i]
         pdgid = int(primary_type[i])
         surfaces.append(nevents * generation_surface(pdgid, spectrum, spatial))
     retval = sum(surfaces)

--- a/src/simweights/_icetop_weighter.py
+++ b/src/simweights/_icetop_weighter.py
@@ -17,24 +17,33 @@ from ._weighter import Weighter
 def sframe_icetop_surface(table: Any) -> GenerationSurface:
     """Inspect the rows of a I3TopInjectorInfo S-Frame table object to generate a surface object."""
     surfaces = []
+    
+    n_events = get_column(table, "n_events")
+    power_law_index = get_column(table, "power_law_index")
+    min_energy = get_column(table, "min_energy")
+    max_energy = get_column(table, "max_energy")
+    sampling_radius = get_column(table, "sampling_radius")
+    max_zenith = np.cos(get_column(table, "max_zenith"))
+    min_zenith = np.cos(get_column(table, "min_zenith"))
+    primary_type = get_column(table, "primary_type")
 
-    for i in range(len(get_column(table, "n_events"))):
-        assert get_column(table, "power_law_index")[i] <= 0
+    for i in range(len(n_events)):
+        assert power_law_index[i] <= 0
         spectrum = PowerLaw(  # pylint: disable=duplicate-code
-            get_column(table, "power_law_index")[i],
-            get_column(table, "min_energy")[i],
-            get_column(table, "max_energy")[i],
+            power_law_index[i],
+            min_energy[i],
+            max_energy[i],
             "energy",
         )
         spatial = NaturalRateCylinder(
             0,  # set cylinder height to 0 to get simple surface plane
-            get_column(table, "sampling_radius")[i],
-            np.cos(get_column(table, "max_zenith")[i]),
-            np.cos(get_column(table, "min_zenith")[i]),
+            sampling_radius[i],
+            max_zenith[i],
+            min_zenith[i],
             "cos_zen",
         )
-        nevents = get_column(table, "n_events")[i]
-        pdgid = int(get_column(table, "primary_type")[i])
+        nevents = n_events[i]
+        pdgid = int(primary_type[i])
         surfaces.append(nevents * generation_surface(pdgid, spectrum, spatial))
     retval = sum(surfaces)
     assert isinstance(retval, GenerationSurface)


### PR DESCRIPTION
Load all columns before creating the generation surfaces. This makes the loading faster, because the h5 table columns don't have to be loaded and converted in every repetition of the for loop