### PR TITLE
Adding another effective area weighting test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,8 @@ select = ["ALL"]
   "SLF001",  # private-member-access
   "PLR2004",  # magic-value-comparison
   "PLR0915",  # too-many-statements
-  "S307"  # suspicious-eval-usage
+  "S307",  # suspicious-eval-usage
+  "ARG005"  # unused function argument
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/tests/test_weighter.py
+++ b/tests/test_weighter.py
@@ -218,7 +218,7 @@ class TestWeighter(unittest.TestCase):
             6,
         )
         self.assertAlmostEqual(
-            self.weighter1.effective_area([5e5, 5e6], [0, 1], flux=lambda energy, pdgid: energy**(-2.7))[0][0],
+            self.weighter1.effective_area([5e5, 5e6], [0, 1], flux=lambda energy, pdgid: energy ** (-2.7))[0][0],
             149998.7936752823,
             6,
         )

--- a/tests/test_weighter.py
+++ b/tests/test_weighter.py
@@ -217,6 +217,11 @@ class TestWeighter(unittest.TestCase):
             149998.97822505102,
             6,
         )
+        self.assertAlmostEqual(
+            self.weighter1.effective_area([5e5, 5e6], [0, 1], flux=lambda energy, pdgid: energy**(-2.7))[0][0],
+            149998.7936752823,
+            6,
+        )
 
         with self.assertRaises(ValueError):
             self.weighter1.effective_area([5e5, 5e6], [0, 1], flux="flux")


### PR DESCRIPTION
Adding a test for the weighted version of effective area with a lambda function for an E^-2.7 spectrum. Note the pdgid necessary for get_weights()