### PR TITLE
Correct the 4-component parameterization of GST

### DIFF
--- a/examples/icetop_book.py
+++ b/examples/icetop_book.py
@@ -6,7 +6,7 @@
 
 from pathlib import Path
 
-from icecube import icetray, hdfwriter, simclasses
+from icecube import hdfwriter, icetray, simclasses
 
 # The following is an example of some "Level3" files for which S-frames were retrofitted
 # after production.  But the input can be any IceTop simulation files containing S-frames.

--- a/examples/nugen_book.py
+++ b/examples/nugen_book.py
@@ -6,7 +6,7 @@
 
 from pathlib import Path
 
-from icecube import icetray, hdfwriter, simclasses
+from icecube import hdfwriter, icetray, simclasses
 
 FILE_DIR = Path("/data/sim/IceCube/2016/filtered/level2/neutrino-generator/21217/0000000-0000999/")
 files = sorted(str(f) for f in FILE_DIR.glob("Level2_IC86.2016_NuMu.021217.0000*.i3.zst"))

--- a/examples/triggered_corsika_book.py
+++ b/examples/triggered_corsika_book.py
@@ -6,7 +6,7 @@
 
 from pathlib import Path
 
-from icecube import icetray, hdfwriter, simclasses
+from icecube import hdfwriter, icetray, simclasses
 
 FILE_DIR = Path("/data/sim/IceCube/2016/filtered/level2/CORSIKA-in-ice/21889/0000000-0000999")
 files = sorted(str(f) for f in FILE_DIR.glob("Level2_IC86.2016_corsika.021889.00000*.i3.zst"))

--- a/src/simweights/_fluxes.py
+++ b/src/simweights/_fluxes.py
@@ -313,17 +313,17 @@ class GlobalFitGST(CosmicRayFlux):
 class GlobalFitGST_IT(CosmicRayFlux):  # pylint: disable=invalid-name
     r"""GlobalFitGST for four components [p, He, O, Fe].
 
-    The Oxygen group is the sum of Nitrogen and Aluminum groups of GlobalFitGST.
+    The Oxygen group is the sum of Carbon and Oxygen groups.
     """
 
     pdgids = PDGID_4COMP
     _funcs = (
         lambda E: 0.7 * E**-2.66 * exp(-E / 1.2e5) + 0.015 * E**-2.4 * exp(-E / 4e6) + 0.0014 * E**-2.4 * exp(-E / 1.3e9),
         lambda E: 0.32 * E**-2.58 * exp(-E / 1.2e5 / 2) + 0.0065 * E**-2.3 * exp(-E / 4e6 / 2),
-        lambda E: 0.01 * E**-2.40 * exp(-E / 1.2e5 / 7)
-        + 0.0006 * E**-2.3 * exp(-E / 4e6 / 7)
-        + 0.013 * E**-2.40 * exp(-E / 1.2e5 / 13)
-        + 0.0007 * E**-2.3 * exp(-E / 4e6 / 13),
+        lambda E: 0.01 * E**-2.40 * exp(-E / 1.2e5 / 6)
+        + 0.0006 * E**-2.3 * exp(-E / 4e6 / 6)
+        + 0.013 * E**-2.40 * exp(-E / 1.2e5 / 8)
+        + 0.0007 * E**-2.3 * exp(-E / 4e6 / 8),
         lambda E: 0.006 * E**-2.30 * exp(-E / 1.2e5 / 26)
         + 0.00023 * E**-2.2 * exp(-E / 4e6 / 26)
         + 0.0000025 * E**-2.2 * exp(-E / 1.3e9 / 26),


### PR DESCRIPTION
The original GST paper (http://doi.org/10.1007/s11467-013-0319-7) gives a parameterization of the CR flux in several populations based on p, He, C, O and Fe mass groups (Table 3). I see that this doesn't match the 5-component model that is used in some working groups (that's why I didn't touch the 5-component model) but for the 4-component version it would be appropriate to use the correct Z values and combine C and O.