### PR TITLE
Update test datasets

### DIFF
--- a/contrib/book_simweights_testdata.py
+++ b/contrib/book_simweights_testdata.py
@@ -121,6 +121,6 @@ print(f"Writing tarfile {tarfilename}")
 with tarfile.open(tarfilename, "w:gz") as tar:
     for f in outdir.iterdir():
         print(f"Adding {f} to tarball")
-        tar.add(outdir / f, arcname=f)
+        tar.add(outdir / f, arcname=f.name)
 
 print(f"Finished writing tarfile {tarfilename}")

--- a/contrib/book_simweights_testdata.py
+++ b/contrib/book_simweights_testdata.py
@@ -28,9 +28,6 @@ fake_event_header.event_id = 0
 
 filelist = {
     "corsika": [
-        "/data/sim/IceCube/2015/filtered/level2/CORSIKA-in-ice/12602/0000000-0000999/Level2_IC86.2015_corsika.012602.000000.i3.bz2",
-        "/data/sim/IceCube/2015/filtered/level2/CORSIKA-in-ice/20014/0000000-0000999/Level2_IC86.2015_corsika.020014.000000.i3.bz2",
-        "/data/sim/IceCube/2015/filtered/level2/CORSIKA-in-ice/20021/0000000-0000999/Level2_IC86.2015_corsika.020021.000000.i3.bz2",
         "/data/sim/IceCube/2016/filtered/level2/CORSIKA-in-ice/20208/0000000-0000999/Level2_IC86.2016_corsika.020208.000001.i3.bz2",
         "/data/sim/IceCube/2016/filtered/level2/CORSIKA-in-ice/20243/0000000-0000999/Level2_IC86.2016_corsika.020243.000001.i3.bz2",
         "/data/sim/IceCube/2016/filtered/level2/CORSIKA-in-ice/20263/0000000-0000999/Level2_IC86.2016_corsika.020263.000000.i3.zst",
@@ -38,19 +35,9 @@ filelist = {
         "/data/sim/IceCube/2016/filtered/level2/CORSIKA-in-ice/20778/0000000-0000999/Level2_IC86.2016_corsika.020778.000000.i3.zst",
         "/data/sim/IceCube/2016/filtered/level2/CORSIKA-in-ice/20780/0000000-0000999/Level2_IC86.2016_corsika.020780.000000.i3.zst",
         "/data/sim/IceCube/2016/filtered/level2/CORSIKA-in-ice/21889/0000000-0000999/Level2_IC86.2016_corsika.021889.000000.i3.zst",
+        "/data/sim/IceCube/2023/filtered/level2/CORSIKA-in-ice/23111/0000000-0000999/Level2_IC86.2024_corsika.023111.000000.i3.zst",
     ],
     "nugen": [
-        "/data/sim/IceCube/2011/filtered/level2/neutrino-generator/10634/00000-00999/Level2_IC86.2011_nugen_NuMu.010634.000000.i3.bz2",
-        "/data/sim/IceCube/2011/filtered/level2/neutrino-generator/10692/00000-00999/Level2_IC86.2011_nugen_NuE.010692.000000.i3.bz2",
-        "/data/sim/IceCube/2012/filtered/level2/neutrino-generator/11029/00000-00999/Level2_nugen_numu_IC86.2012.011029.000000.i3.bz2",
-        "/data/sim/IceCube/2012/filtered/level2/neutrino-generator/11065/00000-00999/Level2_IC86.2012_nugen_NuTau.011065.000001.i3.bz2",
-        "/data/sim/IceCube/2012/filtered/level2/neutrino-generator/11069/00000-00999/Level2_nugen_numu_IC86.2012.011069.000000.i3.bz2",
-        "/data/sim/IceCube/2012/filtered/level2/neutrino-generator/11070/00000-00999/Level2_nugen_numu_IC86.2012.011070.000000.i3.bz2",
-        "/data/sim/IceCube/2012/filtered/level2/neutrino-generator/11297/00000-00999/Level2_nugen_nutau_IC86.2012.011297.000000.i3.bz2",
-        "/data/sim/IceCube/2012/filtered/level2/neutrino-generator/11374/00000-00999/clsim-base-4.0.3.0.99_eff/Level2_IC86.2012_nugen_numu.011374.000050.clsim-base-4.0.3.0.99_eff.i3.bz2",
-        "/data/sim/IceCube/2012/filtered/level2/neutrino-generator/11477/00000-00999/clsim-base-4.0.3.0.99_eff/Level2_IC86.2012_nugen_nutau.011477.000000.clsim-base-4.0.3.0.99_eff.i3.bz2",
-        "/data/sim/IceCube/2012/filtered/level2/neutrino-generator/11836/00000-00999/clsim-base-4.0.3.0.99_eff/Level2_IC86.2012_nugen_nutau.011836.000000.clsim-base-4.0.3.0.99_eff.i3.bz2",
-        "/data/sim/IceCube/2012/filtered/level2/neutrino-generator/12646/0000000-0000999/clsim-base-4.0.5.0.99_eff/Level2_IC86.2012_nugen_nue.012646.000000.clsim-base-4.0.5.0.99_eff.i3.bz2",
         "/data/sim/IceCube/2016/filtered/level2/neutrino-generator/20878/0000000-0000999/Level2_IC86.2016_NuMu.020878.000000.i3.zst",
         "/data/sim/IceCube/2016/filtered/level2/neutrino-generator/20885/0000000-0000999/Level2_IC86.2016_NuE.020885.000000.i3.zst",
         "/data/sim/IceCube/2016/filtered/level2/neutrino-generator/20895/0000000-0000999/Level2_IC86.2016_NuTau.020895.000000.i3.zst",
@@ -71,7 +58,6 @@ filelist = {
 }
 keys = {
     "corsika": [
-        "PolyplopiaPrimary",
         "I3PrimaryInjectorInfo",
         "I3CorsikaInfo",
         "CorsikaWeightMap",

--- a/src/simweights/_corsika_weighter.py
+++ b/src/simweights/_corsika_weighter.py
@@ -25,12 +25,7 @@ class CorsikaSurface(GenerationSurface):
 
     def get_epdf(self: CorsikaSurface, weight_cols: Mapping[str, NDArray[np.float64]]) -> NDArray[np.float64]:
         """Get the extended pdf of a sample of CORSIKA."""
-        return (
-            self.nevents
-            / weight_cols["event_weight"]
-            * self.power_law.pdf(weight_cols["energy"])
-            / self.spatial.etendue
-        )
+        return self.nevents / weight_cols["event_weight"] * self.power_law.pdf(weight_cols["energy"]) / self.spatial.etendue
 
 
 def sframe_corsika_surface(table: Any) -> CompositeSurface:

--- a/src/simweights/_corsika_weighter.py
+++ b/src/simweights/_corsika_weighter.py
@@ -29,7 +29,7 @@ class CorsikaSurface(GenerationSurface):
             self.nevents
             / weight_cols["event_weight"]
             * self.power_law.pdf(weight_cols["energy"])
-            * self.spatial.pdf(weight_cols["cos_zen"])
+            / self.spatial.etendue
         )
 
 
@@ -164,10 +164,8 @@ def CorsikaWeighter(file_obj: Any, nfiles: float | None = None) -> Weighter:  # 
         weighter.add_weight_column("cos_zen", np.cos(weighter.get_column("I3CorsikaWeight", "zenith")))
         weighter.add_weight_column("event_weight", weighter.get_column("I3CorsikaWeight", "weight"))
     else:
-        energy = weighter.get_column("PolyplopiaPrimary", "energy")
-        weighter.add_weight_column("energy", energy)
-        weighter.add_weight_column("pdgid", weighter.get_column("PolyplopiaPrimary", "type"))
-        weighter.add_weight_column("cos_zen", np.cos(weighter.get_column("PolyplopiaPrimary", "zenith")))
-        weighter.add_weight_column("event_weight", np.full(len(energy), 1))
+        weighter.add_weight_column("energy", weighter.get_column("CorsikaWeightMap", "PrimaryEnergy"))
+        weighter.add_weight_column("pdgid", weighter.get_column("CorsikaWeightMap", "PrimaryType").astype(np.int64))
+        weighter.add_weight_column("event_weight", weighter.get_column("CorsikaWeightMap", "Weight"))
 
     return weighter

--- a/tests/test_corsika_datasets.py
+++ b/tests/test_corsika_datasets.py
@@ -27,19 +27,6 @@ datadir = os.environ.get("SIMWEIGHTS_TESTDATA", None)
 if datadir:
     datadir = Path(datadir)
 
-datasets = [
-    pytest.param(False, "Level2_IC86.2015_corsika.012602.000000", 101.71983520393832, id="12602"),
-    pytest.param(False, "Level2_IC86.2015_corsika.020014.000000", 22.857025444108743, id="20014"),
-    pytest.param(False, "Level2_IC86.2015_corsika.020021.000000", 68.93732262681625, id="20021"),
-    pytest.param(False, "Level2_IC86.2016_corsika.020208.000001", 12.397742530207822, id="20208"),
-    pytest.param(False, "Level2_IC86.2016_corsika.020243.000001", 3.302275062730073, id="20243"),
-    pytest.param(False, "Level2_IC86.2016_corsika.020263.000000", 5.3137132171197905, id="20263"),
-    pytest.param(False, "Level2_IC86.2016_corsika.020777.000000", 359.20422121174204, id="20777"),
-    pytest.param(False, "Level2_IC86.2016_corsika.020778.000000", 6.25969855736358, id="20778"),
-    pytest.param(False, "Level2_IC86.2016_corsika.020780.000000", 13.864780296171585, id="20780"),
-    pytest.param(True, "Level2_IC86.2016_corsika.021889.000000", 122.56278334422919, id="21889"),
-]
-
 loaders = [
     pytest.param(lambda f: h5py.File(str(f) + ".hdf5", "r"), id="h5py"),
     pytest.param(lambda f: uproot.open(str(f) + ".root"), id="uproot"),
@@ -100,19 +87,22 @@ def triggered_weights(f):
 
     return i3cw["weight"] * flux_val / epdf
 
+datasets = [
+    pytest.param(untriggered_weights, 1, "Level2_IC86.2016_corsika.020208.000001", 12.397742530207822, id="20208"),
+    pytest.param(untriggered_weights, 1, "Level2_IC86.2016_corsika.020243.000001", 3.302275062730073, id="20243"),
+    pytest.param(untriggered_weights, 1, "Level2_IC86.2016_corsika.020263.000000", 5.3137132171197905, id="20263"),
+    pytest.param(untriggered_weights, 1, "Level2_IC86.2016_corsika.020777.000000", 359.20422121174204, id="20777"),
+    pytest.param(untriggered_weights, 1, "Level2_IC86.2016_corsika.020778.000000", 6.25969855736358, id="20778"),
+    pytest.param(untriggered_weights, 1, "Level2_IC86.2016_corsika.020780.000000", 13.864780296171585, id="20780"),
+    pytest.param(triggered_weights, None, "Level2_IC86.2016_corsika.021889.000000", 122.56278334422919, id="21889"),
+    pytest.param(untriggered_weights, None, "Level2_IC86.2024_corsika.023111.000000", 2494.4260561524957, id="023111"),
+]
 
-@pytest.mark.parametrize(("triggered", "fname", "rate"), datasets)
+@pytest.mark.parametrize(("refweight","nfiles", "fname", "rate"), datasets)
 @pytest.mark.parametrize("loader", loaders)
 @pytest.mark.skipif(not datadir, reason="environment variable SIMWEIGHTS_TESTDATA not set")
-def test_dataset(triggered, fname, rate, loader):
+def test_dataset(refweight, nfiles, fname, rate, loader):
     fname = datadir / fname
-
-    if triggered:
-        nfiles = None
-        refweight = triggered_weights
-    else:
-        nfiles = 1
-        refweight = untriggered_weights
 
     reffile = h5py.File(str(fname) + ".hdf5", "r")
     w0 = refweight(reffile)
@@ -125,21 +115,17 @@ def test_dataset(triggered, fname, rate, loader):
     infile.close()
 
 
-@pytest.mark.parametrize(("triggered", "fname", "rate"), datasets)
+@pytest.mark.parametrize(("refweight","nfiles", "fname", "rate"), datasets)
 @pytest.mark.skipif(not datadir, reason="environment variable SIMWEIGHTS_TESTDATA not set")
 @pytest.mark.skipif("dataio" not in globals(), reason="Not in an IceTray environment")
-def test_dataset_i3file(triggered, fname, rate):
+def test_dataset_i3file(refweight,nfiles, fname, rate):
     fname = datadir / fname
 
     reffile = h5py.File(str(fname) + ".hdf5", "r")
-    if triggered:
-        nfiles = None
-        refweight = triggered_weights
+    if "I3PrimaryInjectorInfo" in reffile:
         counts = np.unique(reffile["I3PrimaryInjectorInfo"]["primary_type"], return_counts=True)
         s_frame_counts = {counts[0][i]: counts[1][i] for i in range(len(counts[0]))}
     else:
-        nfiles = 1
-        refweight = untriggered_weights
         s_frame_counts = dict.fromkeys(set(reffile["CorsikaWeightMap"]["PrimaryType"]), 1)
 
     w0 = refweight(reffile)

--- a/tests/test_corsika_datasets.py
+++ b/tests/test_corsika_datasets.py
@@ -87,6 +87,7 @@ def triggered_weights(f):
 
     return i3cw["weight"] * flux_val / epdf
 
+
 datasets = [
     pytest.param(untriggered_weights, 1, "Level2_IC86.2016_corsika.020208.000001", 12.397742530207822, id="20208"),
     pytest.param(untriggered_weights, 1, "Level2_IC86.2016_corsika.020243.000001", 3.302275062730073, id="20243"),
@@ -98,7 +99,8 @@ datasets = [
     pytest.param(untriggered_weights, None, "Level2_IC86.2024_corsika.023111.000000", 2494.4260561524957, id="023111"),
 ]
 
-@pytest.mark.parametrize(("refweight","nfiles", "fname", "rate"), datasets)
+
+@pytest.mark.parametrize(("refweight", "nfiles", "fname", "rate"), datasets)
 @pytest.mark.parametrize("loader", loaders)
 @pytest.mark.skipif(not datadir, reason="environment variable SIMWEIGHTS_TESTDATA not set")
 def test_dataset(refweight, nfiles, fname, rate, loader):
@@ -115,10 +117,10 @@ def test_dataset(refweight, nfiles, fname, rate, loader):
     infile.close()
 
 
-@pytest.mark.parametrize(("refweight","nfiles", "fname", "rate"), datasets)
+@pytest.mark.parametrize(("refweight", "nfiles", "fname", "rate"), datasets)
 @pytest.mark.skipif(not datadir, reason="environment variable SIMWEIGHTS_TESTDATA not set")
 @pytest.mark.skipif("dataio" not in globals(), reason="Not in an IceTray environment")
-def test_dataset_i3file(refweight,nfiles, fname, rate):
+def test_dataset_i3file(refweight, nfiles, fname, rate):
     fname = datadir / fname
 
     reffile = h5py.File(str(fname) + ".hdf5", "r")

--- a/tests/test_corsika_weighter.py
+++ b/tests/test_corsika_weighter.py
@@ -87,7 +87,7 @@ def test_old_corsika(oversampling, nfiles, flux):
     d = make_corsika_data(2212, 10000, c1, p1)
 
     d["OverSampling"] = oversampling
-    wobj = CorsikaWeighter({"CorsikaWeightMap":d}, nfiles=nfiles)
+    wobj = CorsikaWeighter({"CorsikaWeightMap": d}, nfiles=nfiles)
 
     w = wobj.get_weights(flux)
     np.testing.assert_allclose(
@@ -100,10 +100,10 @@ def test_old_corsika(oversampling, nfiles, flux):
     np.testing.assert_allclose(y, flux * Ewidth * c1.etendue / nfiles / oversampling, 5e-3)
 
     with pytest.raises(RuntimeError):
-        CorsikaWeighter({"CorsikaWeigthMap":d})
+        CorsikaWeighter({"CorsikaWeigthMap": d})
 
     with pytest.raises(TypeError):
-        CorsikaWeighter({"CorsikaWeigthMap":d}, nfiles=object())
+        CorsikaWeighter({"CorsikaWeigthMap": d}, nfiles=object())
 
     with pytest.raises(RuntimeError):
         x = {"CorsikaWeightMap": {"ParticleType": []}, "PolyplopiaPrimary": {}}
@@ -259,11 +259,11 @@ def test_sframe_corsika_i3files(oversampling, n_events, flux):
     wm = dataclasses.I3MapStringDouble()
     wm["PrimaryEnergy"] = d["PrimaryEnergy"][0]
     wm["PrimaryType"] = d["PrimaryType"][0]
-    wm["Weight"]  = 1.
+    wm["Weight"] = 1.0
 
     frame = icetray.I3Frame()
     frame["I3CorsikaInfo"] = info
-    frame["CorsikaWeightMap"]  = wm
+    frame["CorsikaWeightMap"] = wm
     w = CorsikaWeighter(frame).get_weights(flux)
     assert w == approx(flux * c1.etendue / p1.pdf(wm["PrimaryEnergy"]) / n_events / oversampling)
 

--- a/tests/test_nugen_datasets.py
+++ b/tests/test_nugen_datasets.py
@@ -25,17 +25,6 @@ datasets = [
     "Level2_IC86.2016_NuE.020885.000000",
     "Level2_IC86.2016_NuMu.020878.000000",
     "Level2_IC86.2016_NuTau.020895.000000",
-    "Level2_IC86.2012_nugen_nue.012646.000000.clsim-base-4.0.5.0.99_eff",
-    "Level2_IC86.2012_nugen_nutau.011836.000000.clsim-base-4.0.3.0.99_eff",
-    "Level2_IC86.2012_nugen_nutau.011477.000000.clsim-base-4.0.3.0.99_eff",
-    "Level2_IC86.2012_nugen_numu.011374.000050.clsim-base-4.0.3.0.99_eff",
-    "Level2_nugen_nutau_IC86.2012.011297.000000",
-    "Level2_nugen_numu_IC86.2012.011070.000000",
-    "Level2_nugen_numu_IC86.2012.011069.000000",
-    "Level2_IC86.2012_nugen_NuTau.011065.000001",
-    "Level2_nugen_numu_IC86.2012.011029.000000",
-    "Level2_IC86.2011_nugen_NuE.010692.000000",
-    "Level2_IC86.2011_nugen_NuMu.010634.000000",
 ]
 loaders = [
     pytest.param(lambda f: h5py.File(f"{f}.hdf5", "r"), id="h5py"),

--- a/tests/test_nugen_weighter.py
+++ b/tests/test_nugen_weighter.py
@@ -85,6 +85,13 @@ def test_two_nugen_surfaces():
 
     assert wc.sum() / (p2.b - p1.a) / c1.etendue == approx(1, 1e-5)
 
+    assert s0.equivalent(s0) is True
+    assert s2.equivalent(s2) is True
+    assert s0.equivalent(s2) is False
+    assert s2.equivalent(s0) is False
+    assert s0.equivalent(object()) is False
+    assert s0.equivalent(33) is False
+
 
 @pytest.mark.parametrize("weight", (0.1, 1, 10))
 @pytest.mark.parametrize("nfiles", (1, 10, 100))


### PR DESCRIPTION
Many of the datasets we were using were deleted from data/sim because
they were old and obsolete. So they were removed from from the list
of tested datasets. The CORSIKA dataset 23111 was added as the first
S-Frame CORSIKA dataset was added. L2 files for 23111 don't have
PolyplopiaPrimary so CorsikaWeighter was modified to just use
CorsikaWeightMap instead.
