### PR TITLE
upgrade to actions/checkout@v5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           - python-version: "3.13"
             os: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -118,7 +118,7 @@ jobs:
       UV_SYSTEM_PYTHON: 1
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
For some reason PRs initiated by dependaclanker can't access GH secrets.
This causes the pr to fail because it can't download the test data. It
would probably work to just accept the PR but lets test major upgrades
to the CI
